### PR TITLE
Fix initialization for star field

### DIFF
--- a/script.js
+++ b/script.js
@@ -7,7 +7,6 @@ function resize() {
   createStarField();
 }
 window.addEventListener('resize', resize);
-resize();
 
 // approximate centaur constellation
 const stars = [
@@ -92,5 +91,5 @@ function draw() {
   requestAnimationFrame(draw);
 }
 
-createStarField();
+resize();
 requestAnimationFrame(draw);


### PR DESCRIPTION
## Summary
- call `resize()` after variables are declared so `fieldStars` is initialized before use

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_686e69cce2dc8320bed1987fb9856cd2